### PR TITLE
Fix/font block syntax

### DIFF
--- a/Lines.red
+++ b/Lines.red
@@ -71,7 +71,7 @@ do [
 	
 	[
 	  append win compose/deep [
-			panel (color) 250x45 [below text (name) font-size: 14 font-color: 0.33.147 font-name: tube_font]
+			panel (color) 250x45 [below text (name) font [size: 14 color: 0.33.147 name: tube_font]]
 			cursor hand on-down [
 				view [title (name)
 					backdrop (color)
@@ -87,7 +87,7 @@ do [
 	
 	[
 	  append win compose/deep [
-			panel (color) 250x45 [below text (name) font-size: 14 font-color: white font-name: tube_font]
+			panel (color) 250x45 [below text (name) font [size: 14 color: white name: tube_font]]
 			cursor hand on-down [
 				view [title (name)
 					backdrop (color)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clone this repo and run:
 red -c -r Lines.red
 ```
 
-Tested on macOS with Red 0.6.3 stable.
+Tested on macOS with Red 0.6.4 stable.
 
 Note this command should work on Windows and Mac. However, since GUI support is not available on Linux, This clone of lines is not supported for now.
 


### PR DESCRIPTION
Fix broken syntax around font blocks for Red 0.6.4.
Also updated README to reflect the change.